### PR TITLE
Adding support to look for view under specific view tree instead of always root application

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.h
+++ b/Additions/UIAccessibilityElement-KIFAdditions.h
@@ -35,6 +35,20 @@
 + (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable error:(out NSError **)error;
 
 /*!
+ @abstract Finds an accessibility element and view with a matching label, value, and traits, optionally passing a tappability test.
+ @discussion This method combines @c +accessibilityElementWithLabel:value:traits:error: and @c +viewContainingAccessibilityElement:tappable:error: for convenience.
+ @param foundElement The found accessibility element or @c nil if the method returns @c NO.  Can be @c NULL.
+ @param foundView The first matching view for @c foundElement as determined by the accessibility API or @c nil if the view is hidden or fails the tappability test. Can be @c NULL.
+ @param label The accessibility label of the element to wait for.
+ @param value The accessibility value of the element to tap.
+ @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.
+ @param fromView The root view to start looking for the accessibility element.
+ @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
+ @result @c YES if the element and view were found.  Otherwise @c NO.
+ */
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError **)error;
+
+/*!
  @abstract Finds an accessibility element with a matching label, value, and traits.
  @discussion This functionality is identical to <tt>-[UIApplication accessibilityElementWithLabel:accessibilityValue:traits:]</tt> except that it detailed error messaging in the case where the element cannot be found.
  @param label The accessibility label of the element to wait for.
@@ -44,6 +58,29 @@
  @return The found accessibility element.  If @c nil see the @c error for a detailed reason.
  */
 + (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits error:(out NSError **)error;
+
+/*!
+ @abstract Finds an accessibility element with a matching label, value, and traits from specified root view.
+ @discussion This functionality is identical to <tt>-[UIApplication accessibilityElementWithLabel:accessibilityValue:traits:]</tt> except that it detailed error messaging in the case where the element cannot be found.
+ @param label The accessibility label of the element to wait for.
+ @param value The accessibility value of the element to tap.
+ @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.
+ @param fromRootView The root view to start looking for the accessibility element.
+ @param error A reference to an error object to be populated when no element is found.  Can be @c NULL.
+ @return The found accessibility element.  If @c nil see the @c error for a detailed reason.
+ */
++ (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView error:(out NSError **)error;
+
+/*!
+ @abstract Finds an accessibility element and view from the specified root view where the element passes the predicate, optionally passing a tappability test.
+ @param foundElement The found accessibility element or @c nil if the method returns @c NO.  Can be @c NULL.
+ @param foundView The first matching view for @c foundElement as determined by the accessibility API or @c nil if the view is hidden or fails the tappability test. Can be @c NULL.
+ @param fromRootView The root view to start looking for the accessibility element.
+ @param predicate The predicate to test the accessibility element on.
+ @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
+ @result @c YES if the element and view were found.  Otherwise @c NO.
+ */
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withElementMatchingPredicate:(NSPredicate *)predicate fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError **)error;
 
 /*!
  @abstract Finds an accessibility element and view where the element passes the predicate, optionally passing a tappability test.

--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -37,9 +37,14 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     return (UIView *)element;
 }
 
-+ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable error:(out NSError **)error;
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable error:(out NSError **)error
 {
-    UIAccessibilityElement *element = [self accessibilityElementWithLabel:label value:value traits:traits error:error];
+    return [self accessibilityElement:foundElement view:foundView withLabel:label value:value traits:traits fromRootView:NULL tappable:mustBeTappable error:error];
+}
+
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError **)error
+{
+    UIAccessibilityElement *element = [self accessibilityElementWithLabel:label value:value traits:traits fromRootView:fromView error:error];
     if (!element) {
         return NO;
     }
@@ -77,9 +82,42 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     return YES;
 }
 
-+ (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits error:(out NSError **)error;
++ (BOOL)accessibilityElement:(out UIAccessibilityElement *__autoreleasing *)foundElement view:(out UIView *__autoreleasing *)foundView withElementMatchingPredicate:(NSPredicate *)predicate fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError *__autoreleasing *)error
 {
-    UIAccessibilityElement *element = [[UIApplication sharedApplication] accessibilityElementWithLabel:label accessibilityValue:value traits:traits];
+    UIAccessibilityElement *element = [fromView accessibilityElementMatchingBlock:^BOOL(UIAccessibilityElement *element) {
+        return [predicate evaluateWithObject:element];
+    }];
+    
+    if (!element) {
+        if (error) {
+            *error = [NSError KIFErrorWithFormat:@"Could not find view matching: %@", predicate];
+        }
+        return NO;
+    }
+    
+    UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element tappable:mustBeTappable error:error];
+    if (!view) {
+        return NO;
+    }
+    
+    if (foundElement) { *foundElement = element; }
+    if (foundView) { *foundView = view; }
+    return YES;
+}
+
++ (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits error:(out NSError **)error
+{
+    return [self accessibilityElementWithLabel:label value:value traits:traits fromRootView:NULL error:error];
+}
+
++ (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView error:(out NSError **)error;
+{
+    UIAccessibilityElement *element = NULL;
+    if (fromView == NULL) {
+        element = [[UIApplication sharedApplication] accessibilityElementWithLabel:label accessibilityValue:value traits:traits];
+    } else {
+        element = [fromView accessibilityElementWithLabel:label accessibilityValue:value traits:traits];
+    }
     if (element || !error) {
         return element;
     }

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -156,6 +156,19 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable;
 
 /*!
+ @abstract Waits for an accessibility element and its containing view from specified root view based on a variety of criteria.
+ @discussion This method provides a more verbose API for achieving what is available in the waitForView/waitForTappableView family of methods, exposing both the found element and its containing view.  The results can be used in other methods such as @c tapAccessibilityElement:inView:
+ @param element To be populated with the matching accessibility element when found.  Can be NULL.
+ @param view To be populated with the matching view when found.  Can be NULL.
+ @param label The accessibility label of the element to wait for.
+ @param value The accessibility value of the element to tap.
+ @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.
+ @param fromRootView The root view to start looking for accessibility element.
+ @param mustBeTappable If YES, only an element that can be tapped on will be returned.
+ */
+- (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable;
+
+/*!
  @abstract Waits for an accessibility element and its containing view based the accessibility identifier.
  @discussion This method provides a more verbose API for achieving what is available in the waitForView/waitForTappableView family of methods, exposing both the found element and its containing view.  The results can be used in other methods such as @c tapAccessibilityElement:inView:
  @param element To be populated with the matching accessibility element when found.  Can be NULL.
@@ -164,6 +177,17 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @param mustBeTappable If YES, only an element that can be tapped on will be returned.
  */
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withIdentifier:(NSString *)identifier tappable:(BOOL)mustBeTappable;
+
+/*!
+ @abstract Waits for an accessibility element and its containing view from specified root view based the accessibility identifier.
+ @discussion This method provides a more verbose API for achieving what is available in the waitForView/waitForTappableView family of methods, exposing both the found element and its containing view.  The results can be used in other methods such as @c tapAccessibilityElement:inView:
+ @param element To be populated with the matching accessibility element when found.  Can be NULL.
+ @param view To be populated with the matching view when found.  Can be NULL.
+ @param identifier The accessibility identifier of the element to wait for.
+ @param fromRootView The root view to start looking for accessibility element.
+ @param mustBeTappable If YES, only an element that can be tapped on will be returned.
+ */
+- (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withIdentifier:(NSString *)identifier fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable;
 
 /*!
  @abstract Waits for an accessibility element and its containing view based on a predicate.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -74,6 +74,13 @@
     }];
 }
 
+- (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable
+{
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        return [UIAccessibilityElement accessibilityElement:element view:view withLabel:label value:value traits:traits fromRootView:fromView tappable:mustBeTappable error:error];
+    }];
+}
+
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withIdentifier:(NSString *)identifier tappable:(BOOL)mustBeTappable
 {
     if (![UIAccessibilityElement instancesRespondToSelector:@selector(accessibilityIdentifier)]) {
@@ -81,6 +88,13 @@
     }
     
     [self waitForAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] tappable:mustBeTappable];
+}
+
+- (void)waitForAccessibilityElement:(UIAccessibilityElement *__autoreleasing *)element view:(out UIView *__autoreleasing *)view withIdentifier:(NSString *)identifier fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable
+{
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        return [UIAccessibilityElement accessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] fromRootView:fromView tappable:mustBeTappable error:error] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
+    }];
 }
 
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable

--- a/KIF Tests/TappingTests.m
+++ b/KIF Tests/TappingTests.m
@@ -7,6 +7,7 @@
 //
 
 #import <KIF/KIF.h>
+#import <KIF/KIFUITestActor-IdentifierTests.h>
 
 @interface TappingTests : KIFTestCase
 @end
@@ -21,6 +22,18 @@
 - (void)afterEach
 {
     [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+}
+
+- (void)testTappingViewFromSpecificView
+{
+    UIView *scrollView = [tester waitForViewWithAccessibilityIdentifier:@"TapViewController Inner ScrollView"];
+    UIView *buttonView;
+    UIAccessibilityElement *element;
+    [tester waitForAccessibilityElement:&element view:&buttonView withIdentifier:@"Inner Button" fromRootView:scrollView tappable:YES];
+    
+    if (buttonView != NULL) {
+        [tester tapAccessibilityElement:element inView:buttonView];
+    }
 }
 
 - (void)testTappingViewWithAccessibilityLabel

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -1533,8 +1533,14 @@
                                         <state key="highlighted">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
+                                        <userDefinedRuntimeAttributes>
+                                          <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Inner Button"/>
+                                        </userDefinedRuntimeAttributes>
                                     </button>
                                 </subviews>
+                                <userDefinedRuntimeAttributes>
+                                  <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="TapViewController Inner ScrollView"/>
+                                </userDefinedRuntimeAttributes>
                             </scrollView>
                             <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label with Tap Gesture Recognizer" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eKU-mb-iWm">
                                 <rect key="frame" x="27" y="288" width="267" height="21"/>


### PR DESCRIPTION
The logic to lookup views is always starting at the root (UIApplication).
However, there are requests from different parties on the needs of lookup on a sub tree from specific view.

This is to support the scenario.
