### PR TITLE
Use scroll view delegate to reliably wait for scrolling to finish

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -15,6 +15,8 @@
 #import "UIView-KIFAdditions.h"
 #import "LoadableCategory.h"
 #import "KIFTestActor.h"
+#import "KIFProxyDelegate.h"
+#import "KIFScrollViewDelegates.h"
 
 MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
@@ -168,8 +170,17 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         if ([superview isKindOfClass:[UIScrollView class]]) {
             UIScrollView *scrollView = (UIScrollView *)superview;
             
+            // Replace the scroll view delegate to capture scrolling completion
+            KIFScrollViewDelegate * kifDelegate = [KIFScrollViewDelegate new];
+            KIFProxyDelegate * delegate = [[KIFProxyDelegate alloc] initWithOriginalDelegate:scrollView.delegate
+                                                                         replacementDelegate:kifDelegate];
+            scrollView.delegate = (id<UIScrollViewDelegate>)delegate;
+            
             if (((UIAccessibilityElement *)view == element) && ![view isKindOfClass:[UITableViewCell class]]) {
+                // Initiate scrolling
                 [scrollView scrollViewToVisible:view animated:YES];
+                // Wait for scrolling to finish
+                [kifDelegate waitForScrollCompleteOnView:view inScrollView:scrollView];
             } else {
                 CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
                 CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
@@ -177,12 +188,15 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
                 // Only call scrollRectToVisible if the element isn't already visible
                 // iOS 8 will sometimes incorrectly scroll table views so the element scrolls out of view
                 if (!CGRectContainsRect(visibleRect, elementFrame)) {
+                    // Initiate scrolling
                     [scrollView scrollRectToVisible:elementFrame animated:YES];
+                    // Wait for scrolling to finish
+                    [kifDelegate waitForScrollCompleteOnView:view inScrollView:scrollView];
                 }
             }
             
-            // Give the scroll view a small amount of time to perform the scroll.
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.3 / UIApplication.sharedApplication.keyWindow.layer.speed, false);
+            // Restore the delegate to original
+            scrollView.delegate = delegate.original;
         }
         
         superview = superview.superview;

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -14,6 +14,8 @@
 #import "UITouch-KIFAdditions.h"
 #import <objc/runtime.h>
 #import "UIEvent+KIFAdditions.h"
+#import "KIFProxyDelegate.h"
+#import "KIFScrollViewDelegates.h"
 
 double KIFDegreesToRadians(double deg) {
     return (deg) / 180.0 * M_PI;
@@ -249,9 +251,23 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     }
                     
                     // Scroll to the cell and wait for the animation to complete
+                    KIFTableViewDelegate *kifDelegate = [KIFTableViewDelegate new];
+                    KIFProxyDelegate *delegate = [[KIFProxyDelegate alloc] initWithOriginalDelegate:tableView.delegate
+                                                                                replacementDelegate:kifDelegate];
+                    tableView.delegate = (id<UITableViewDelegate>)delegate;
+
+                    // Initiate scrolling
                     [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
-                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
                     
+                    // Wait for scrolling to finish
+                    if (![kifDelegate waitForScrollCompleteToIndexPath:indexPath inTableView:tableView]) {
+                        tableView.delegate = delegate.original;
+                        return nil;
+                    }
+                    
+                    // Restore the delegate to original
+                    tableView.delegate = delegate.original;
+
                     // Now try finding the element again
                     return [self accessibilityElementMatchingBlock:matchBlock];
                 }
@@ -286,9 +302,24 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     }
                     
                     // Scroll to the cell and wait for the animation to complete
+                    KIFCollectionViewDelegate *kifDelegate = [KIFCollectionViewDelegate new];
+                    KIFProxyDelegate *delegate = [[KIFProxyDelegate alloc] initWithOriginalDelegate:collectionView.delegate
+                                                                                replacementDelegate:kifDelegate];
+                    collectionView.delegate = (id<UICollectionViewDelegate>)delegate;
+
+                    // Initiate scrolling
                     CGRect frame = [collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame;
                     [collectionView scrollRectToVisible:frame animated:YES];
-                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
+                    
+                    // Wait for scrolling to finish
+                    if (![kifDelegate waitForScrollCompleteToIndexPath:indexPath
+                                                      inCollectionView:collectionView]) {
+                        collectionView.delegate = delegate.original;
+                        return nil;
+                    }
+                    
+                    // Restore the delegate to original
+                    collectionView.delegate = delegate.original;
                     
                     // Now try finding the element again
                     return [self accessibilityElementMatchingBlock:matchBlock];

--- a/Classes/KIFConstants.h
+++ b/Classes/KIFConstants.h
@@ -1,0 +1,13 @@
+//
+//  KIFConstants.h
+//  KIF
+//
+//  Created by Ashit Gandhi on 7/27/15.
+//
+//
+
+// The amount of time (in seconds) to wait for an event before terminating tests
+#define KIF_WAIT_TIMEOUT_INTERVAL   (30.0)
+
+// The amount of time (in seconds) to run the thread's runlooop before checking state again
+#define KIF_RUNLOOP_INTERVAL        (0.01)

--- a/Classes/KIFProxyDelegate.h
+++ b/Classes/KIFProxyDelegate.h
@@ -1,0 +1,22 @@
+//
+//  KIFProxyDelegate.h
+//  KIF
+//
+//
+
+#import <Foundation/Foundation.h>
+
+/*!
+ * @abstract @c KIFProxyDelegate serves as a proxy delegate between the @c original and @c replacement
+ * @discussion This class lets the @c replacement delegate intercept and act on all messages sent to this object, before @c original gets them. 
+ 
+   @c KIFProxyDelegate @b does @b not retain the delegates, so ensure the object representing the delegate is retain long enough for your use case.
+ */
+@interface KIFProxyDelegate : NSProxy
+
+@property (nonatomic, weak, readonly) id original;
+
+- (instancetype)initWithOriginalDelegate:(id)original
+                     replacementDelegate:(id)replacement;
+
+@end

--- a/Classes/KIFProxyDelegate.m
+++ b/Classes/KIFProxyDelegate.m
@@ -1,0 +1,51 @@
+//
+//  KIFProxyDelegate.m
+//  KIF
+//
+//  Created by Ashit Gandhi on 7/24/15.
+//
+//
+
+#import "KIFProxyDelegate.h"
+
+@interface KIFProxyDelegate ()
+@property (nonatomic, weak, readonly) id replacement;
+@end
+
+@implementation KIFProxyDelegate
+
+- (instancetype)initWithOriginalDelegate:(NSObject *)original
+                     replacementDelegate:(NSObject *)replacement
+{
+    _original = original;
+    _replacement = replacement;
+    return self;
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    if ([self.replacement respondsToSelector:anInvocation.selector]) {
+        [anInvocation invokeWithTarget:self.replacement];
+    }
+
+    if ([self.original respondsToSelector:anInvocation.selector]) {
+        [anInvocation invokeWithTarget:self.original];
+    }
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    if (self.original != nil && [self.original respondsToSelector:aSelector]) {
+        return [self.original methodSignatureForSelector:aSelector];
+    } else {
+        return [self.replacement methodSignatureForSelector:aSelector];
+    }
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    return [self.original respondsToSelector:aSelector] ||
+           [self.replacement respondsToSelector:aSelector];
+}
+
+@end

--- a/Classes/KIFScrollViewDelegates.h
+++ b/Classes/KIFScrollViewDelegates.h
@@ -1,0 +1,47 @@
+//
+//  KIFScrollViewDelegates.h
+//  KIF
+//
+//  Created by Ashit Gandhi on 7/24/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+/*!
+ * @abstract @c Generic scroll view delegate that allows to reliably wait for scrolling to complete.
+ * @discussion Objects of this class can serve a scroll view delegate. 
+               Note that scrolling has to start for the @c waitForScrollComplete* methods to be called.
+ */
+@interface KIFScrollViewDelegate : NSObject<UIScrollViewDelegate>
+
+/*!
+ * @abstract Resets scroll completion state if you want to reuse the same delegate object.
+ */
+- (void)reset;
+
+/*!
+ * @abstract Scrolling wait function for generic scroll views.
+ */
+- (BOOL)waitForScrollCompleteOnView:(UIView *)view inScrollView:(UIScrollView *)scrollView;
+
+@end
+
+@interface KIFCollectionViewDelegate : KIFScrollViewDelegate<UICollectionViewDelegate>
+
+/*!
+ * @abstract Scrolling wait function using collection view cell visibility logic.
+ */
+- (BOOL)waitForScrollCompleteToIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView;
+
+@end
+
+@interface KIFTableViewDelegate : KIFScrollViewDelegate<UITableViewDelegate>
+
+/*!
+ * @abstract Scrolling wait function using table views cell visibility logic.
+ */
+- (BOOL)waitForScrollCompleteToIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView;
+
+@end

--- a/Classes/KIFScrollViewDelegates.m
+++ b/Classes/KIFScrollViewDelegates.m
@@ -1,0 +1,180 @@
+//
+//  KIFScrollViewDelegates.m
+//  KIF
+//
+//  Created by Ashit Gandhi on 7/24/15.
+//
+//
+
+#import "KIFScrollViewDelegates.h"
+#import "KIFConstants.h"
+
+@interface KIFScrollViewDelegate ()
+@property (nonatomic, assign) BOOL scrollViewDidEndScrollingAnimation;
+@end
+
+typedef BOOL (^VisibilityTestBlock)();
+
+@implementation KIFScrollViewDelegate
+
+// UIScrollViewDelegate scrollViewDidScroll
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+    // This ensures that scrollViewDidEndScrollingAnimation is always called,
+    // whether the scrollview is animated or not,
+    // and that it's always called after scrollViewDidScroll,
+    // which could fire synchronously from within the scroll method, thus
+    // completing before any waits have started
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                             selector:@selector(scrollViewDidEndScrollingAnimation:)
+                                               object:nil];
+    [self performSelector:@selector(scrollViewDidEndScrollingAnimation:)
+               withObject:nil
+               afterDelay:0.1f];
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
+{
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                             selector:@selector(scrollViewDidEndScrollingAnimation:)
+                                               object:nil];
+    self.scrollViewDidEndScrollingAnimation = YES;
+}
+
+- (void)reset
+{
+    self.scrollViewDidEndScrollingAnimation = NO;
+}
+
+- (BOOL)waitForScrollCompleteOnView:(UIView *)view inScrollView:(UIScrollView *)scrollView
+{
+    // The UITableViewWrapperView (introduced in iOS7) gets in the way.
+    // It doesn't update its content offset, so we cannot use it to judge if the cell is in view
+    if ([NSStringFromClass([scrollView class]) isEqualToString:@"UITableViewWrapperView"] &&
+        [scrollView.superview isKindOfClass:[UIScrollView class]]) {
+        scrollView = (UIScrollView *)scrollView.superview;
+    }
+
+    return [self waitForScrollViewDidEndScrollingAnimationOnView:^BOOL {
+        CGRect elementFrame = [view.window convertRect:view.accessibilityFrame
+                                                toView:scrollView];
+        CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y,
+                                        CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
+
+        return CGRectContainsRect(visibleRect, elementFrame);
+    }];
+}
+
+- (BOOL)waitForScrollViewDidEndScrollingAnimationOnView:(UIView *)view inScrollView:(UIScrollView *)scrollView
+{
+    @autoreleasepool {
+        NSDate *date;
+        NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:KIF_WAIT_TIMEOUT_INTERVAL]; // max wait timeout
+        CGRect viewFrame;
+        CGRect visibleRect;
+        do {
+            viewFrame = [view.window convertRect:view.frame toView:scrollView];
+            visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y,
+                                     CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
+
+            date = [NSDate dateWithTimeIntervalSinceNow:KIF_RUNLOOP_INTERVAL];
+            [[NSRunLoop currentRunLoop] runUntilDate:date];
+            if ([date compare:timeout] == NSOrderedDescending) {
+                return NO;
+            }
+        } while (!self.scrollViewDidEndScrollingAnimation || !CGRectContainsRect(visibleRect, viewFrame));
+        return YES;
+    }
+}
+
+- (BOOL)waitForScrollViewDidEndScrollingAnimationOnView:(VisibilityTestBlock)isVisibleBlock
+{
+    @autoreleasepool {
+        NSDate *date;
+        NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:KIF_WAIT_TIMEOUT_INTERVAL]; // max wait
+
+        // Ensure that we pump the runloop at least once before bailing
+        do {
+            date = [NSDate dateWithTimeIntervalSinceNow:KIF_RUNLOOP_INTERVAL];
+            [[NSRunLoop currentRunLoop] runUntilDate:date];
+            if ([date compare:timeout] == NSOrderedDescending) {
+                return NO;
+            }
+        } while (!self.scrollViewDidEndScrollingAnimation && !isVisibleBlock());
+        return YES;
+    }
+}
+
+@end
+
+@implementation KIFCollectionViewDelegate
+
+- (BOOL)waitForScrollCompleteToIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView
+{
+    return [self waitForScrollViewDidEndScrollingAnimationOnView:^BOOL {
+        return [KIFCollectionViewDelegate isItemAtIndexPath:indexPath alreadyVisibleIn:collectionView];
+    }];
+}
+
++ (BOOL)isItemAtIndexPath:(NSIndexPath *)indexPath alreadyVisibleIn:(UICollectionView *)collectionView
+{
+    for (UICollectionViewCell * testCell in [collectionView visibleCells]) {
+        NSIndexPath * itemIndexPath = [collectionView indexPathForCell:testCell];
+        if (itemIndexPath.section == indexPath.section && itemIndexPath.item == indexPath.item) {
+            CGRect itemRect = [testCell convertRect:testCell.frame toView:testCell.superview];
+            itemRect = [collectionView convertRect:itemRect toView:collectionView.superview];
+            CGRect collectionViewFrame = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y,
+                                                    collectionView.bounds.size.width, collectionView.bounds.size.height);
+
+            // Check the simplest contained case -- this works only if the item is visible without having to scroll at all
+            BOOL contained = CGRectContainsRect(collectionView.bounds, testCell.frame);
+            if (contained) {
+                return YES;
+            }
+
+            // If the itemRect is larger than the CV or is positioned so that it can never be fully within the VC, only verify if its midpoint is within the CV
+            if (itemRect.size.width > (collectionView.contentOffset.x + collectionViewFrame.size.width) ||
+                itemRect.size.height > (collectionView.contentOffset.y + collectionViewFrame.size.height)) {
+                return CGRectContainsPoint(collectionViewFrame,
+                                           CGPointMake(itemRect.origin.x + (itemRect.size.width/2),
+                                           itemRect.origin.y + (itemRect.size.height/2)));
+            }
+            
+            // This does not work if the itemRect is larger than the collection view
+            return CGRectContainsRect(collectionViewFrame, itemRect);
+        }
+    }
+    return NO;
+}
+
+@end
+
+@implementation KIFTableViewDelegate
+
++ (BOOL)isRowAtIndexPath:(NSIndexPath *)indexPath alreadyVisibleIn:(UITableView *)tableView
+{
+    CGRect rowRect = [tableView rectForRowAtIndexPath:indexPath];
+    rowRect = [tableView convertRect:rowRect toView:tableView.superview];
+
+    // If the row's size (in any dimension) is > the table view's size,
+    // then we should return true if the row's midpoint is visible
+    if (rowRect.size.width > (tableView.contentOffset.x + tableView.frame.size.width) ||
+        rowRect.size.height > (tableView.contentOffset.y + tableView.frame.size.height)) {
+        return CGRectContainsPoint(tableView.frame,
+                                   CGPointMake(rowRect.origin.x + (rowRect.size.width/2),
+                                   rowRect.origin.y + (rowRect.size.height/2)));
+    }
+    
+    // Otherwise, check if the full rect is contained
+    // This does not work if the rowRect is larger than the table view
+    return CGRectContainsRect(tableView.frame, rowRect);
+}
+
+- (BOOL)waitForScrollCompleteToIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView
+{
+    return [self waitForScrollViewDidEndScrollingAnimationOnView:^BOOL {
+        return [KIFTableViewDelegate isRowAtIndexPath:indexPath alreadyVisibleIn:tableView];
+    }];
+}
+
+@end

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -20,6 +20,8 @@
 #import "NSError-KIFAdditions.h"
 #import "KIFTypist.h"
 #import "UIAutomationHelper.h"
+#import "KIFProxyDelegate.h"
+#import "KIFScrollViewDelegates.h"
 
 #define kKIFMinorSwipeDisplacement 5
 
@@ -1044,25 +1046,24 @@
         return KIFTestStepResultSuccess;
     }];
 
-    __block UITableViewCell *cell = nil;
-    __block CGFloat lastYOffset = CGFLOAT_MAX;
-    [self runBlock:^KIFTestStepResult(NSError **error) {
-        [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:[KIFTestActor animation]];
-        cell = [tableView cellForRowAtIndexPath:indexPath];
-        KIFTestWaitCondition(!!cell, error, @"Table view cell at index path %@ not found", indexPath);
-        
-        if (lastYOffset != tableView.contentOffset.y) {
-            lastYOffset = tableView.contentOffset.y;
-            KIFTestWaitCondition(NO, error, @"Didn't finish scrolling to cell.");
-        }
-        
-        return KIFTestStepResultSuccess;
-    }];
+    // Set up a proxy table view delegate, so we know when scrolling has stopped
+    KIFTableViewDelegate *kifDelegate = [KIFTableViewDelegate new];
+    KIFProxyDelegate *delegate = [[KIFProxyDelegate alloc] initWithOriginalDelegate:tableView.delegate
+                                                                replacementDelegate:kifDelegate];
+    tableView.delegate = (id<UITableViewDelegate>)delegate;
 
-    [self waitForTimeInterval:0.1]; // Let things settle.
+    // Initiate scrolling
+    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:[KIFTestActor animation]];
+    
+    // Wait for scrolling to finish
+    if (![kifDelegate waitForScrollCompleteToIndexPath:indexPath inTableView:tableView]) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"Timed out waiting for scroll"] stopTest:YES];
+    }
 
+    // Restore the delegate to the original
+    tableView.delegate = delegate.original;
 
-    return cell;
+    return [tableView cellForRowAtIndexPath:indexPath];
 }
 
 - (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier
@@ -1102,26 +1103,45 @@
         return KIFTestStepResultSuccess;
     }];
 
-    [collectionView scrollToItemAtIndexPath:indexPath
-                           atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically
-                                   animated:[KIFTestActor animation]];
+    // Set up a proxy table view delegate, so we know when scrolling has stopped
+    KIFCollectionViewDelegate *kifDelegate = [KIFCollectionViewDelegate new];
+    KIFProxyDelegate *delegate = [[KIFProxyDelegate alloc] initWithOriginalDelegate:collectionView.delegate
+                                                                replacementDelegate:kifDelegate];
+    collectionView.delegate = (id<UICollectionViewDelegate>)delegate;
 
-    [self waitForAnimationsToFinish];
+    // Initiate scrolling
+    CGRect frame = [collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame;
+    [collectionView scrollRectToVisible:frame animated:[KIFTestActor animation]];
+
+    // Wait for scrolling to finish
+    if (![kifDelegate waitForScrollCompleteToIndexPath:indexPath inCollectionView:collectionView]) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"Timed out waiting for scroll"] stopTest:YES];
+    }
+
     UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
 
     //For big collection views with many cells the cell might not be ready yet. Relayout and try again.
     if(cell == nil) {
         [collectionView layoutIfNeeded];
-        [collectionView scrollToItemAtIndexPath:indexPath
-                               atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically
-                                       animated:[KIFTestActor animation]];
-        [self waitForAnimationsToFinish];
+        
+        // Initiate scrolling
+        CGRect frame = [collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame;
+        [collectionView scrollRectToVisible:frame animated:NO];
+        
+        // Wait for scrolling to finish
+        if (![kifDelegate waitForScrollCompleteToIndexPath:indexPath inCollectionView:collectionView]) {
+            [self failWithError:[NSError KIFErrorWithFormat:@"Timed out waiting for scroll"] stopTest:YES];
+        }
+        
         cell = [collectionView cellForItemAtIndexPath:indexPath];
     }
     
     if (!cell) {
         [self failWithError:[NSError KIFErrorWithFormat:@"Collection view cell at index path %@ not found", indexPath] stopTest:YES];
     }
+
+    // Restore the delegate to the original
+    collectionView.delegate = delegate.original;
 
     return cell;
 }

--- a/KIF Tests/ProxyDelegateTests.m
+++ b/KIF Tests/ProxyDelegateTests.m
@@ -1,0 +1,145 @@
+//
+//  ProxyDelegateTests.m
+//  KIF
+//
+//  Created by Jacek Suliga on 5/23/16.
+//
+//
+
+#import "KIFProxyDelegate.h"
+
+// Helper class for the original delegate
+@interface ProxyTestHelperOrg: NSObject
+
+@property (copy) dispatch_block_t functionAblock;
+@property (copy) dispatch_block_t functionBblock;
+@property (copy) dispatch_block_t functionCblock;
+
+@end
+
+@implementation ProxyTestHelperOrg
+
+-(void)sampleFunctionA
+{
+    if (self.functionAblock) {
+        self.functionAblock();
+    }
+}
+
+-(void)sampleFunctionB:(id)someObject
+{
+    if (self.functionBblock) {
+        self.functionBblock();
+    }
+}
+
+-(void)sampleFunctionC
+{
+    if (self.functionCblock) {
+        self.functionCblock();
+    }
+}
+
+@end
+
+// Helper class for the replacement delegate
+@interface ProxyTestHelperRepl: NSObject
+
+@property (copy) dispatch_block_t functionAblock;
+@property (copy) dispatch_block_t functionBblock;
+@property (copy) dispatch_block_t functionDblock;
+
+@end
+
+@implementation ProxyTestHelperRepl
+
+-(void)sampleFunctionA
+{
+    if (self.functionAblock) {
+        self.functionAblock();
+    }
+}
+
+-(void)sampleFunctionB:(id)someObject
+{
+    if (self.functionBblock) {
+        self.functionBblock();
+    }
+}
+
+-(void)sampleFunctionD
+{
+    if (self.functionDblock) {
+        self.functionDblock();
+    }
+}
+
+@end
+
+
+@interface ProxyDelegateTests: XCTestCase
+@end
+
+@implementation ProxyDelegateTests
+
+-(void)testDelegate {
+    // Configure original "delegate"
+    ProxyTestHelperOrg * original = [ProxyTestHelperOrg new];
+    
+    __block BOOL originalAcalled = NO;
+    __block BOOL originalBcalled = NO;
+    __block BOOL originalCcalled = NO;
+    
+    original.functionAblock = ^{
+        originalAcalled = YES;
+    };
+    original.functionBblock = ^{
+        originalBcalled = YES;
+    };
+    original.functionCblock = ^{
+        originalCcalled = YES;
+    };
+    
+    // Configure replacement "delegate"
+    ProxyTestHelperRepl * replacement = [ProxyTestHelperRepl new];
+    
+    __block BOOL replacementAcalled = NO;
+    __block BOOL replacementBcalled = NO;
+    __block BOOL replacementDcalled = NO;
+    
+    replacement.functionAblock = ^{
+        replacementAcalled = YES;
+    };
+    replacement.functionBblock = ^{
+        replacementBcalled = YES;
+    };
+    replacement.functionDblock = ^{
+        replacementDcalled = YES;
+    };
+    
+    KIFProxyDelegate * proxyDelegate = [[KIFProxyDelegate alloc] initWithOriginalDelegate:original replacementDelegate:replacement];
+    
+    // Calling function A on proxyDelegate should call function A on the replacement and original as well
+    [proxyDelegate performSelector:@selector(sampleFunctionA)];
+    XCTAssert(replacementAcalled && originalAcalled, @"Replacement not called, or original not called!");
+    
+    // Calling function B on proxyDelegate should call function B on the replacement, and original as well
+    [proxyDelegate performSelector:@selector(sampleFunctionB:) withObject:self];
+    XCTAssert(replacementBcalled && originalBcalled, @"Replacement not called, or original not called!");
+    
+    // Calling function C on proxyDelegate should call function C on the original, as replacement does not implement it
+    [proxyDelegate performSelector:@selector(sampleFunctionC)];
+    XCTAssert(originalCcalled, @"Original not called");
+    
+    // Calling function D on proxyDelegate should call function D on the replacement, as only it implements it
+    [proxyDelegate performSelector:@selector(sampleFunctionD)];
+    XCTAssert(replacementDcalled, @"Replacement not called");
+    
+    // Final state for the original delegate
+    XCTAssert(originalAcalled && originalBcalled && originalCcalled, @"Original not called");
+    
+    // Final state for the replacement delegate
+    XCTAssert(replacementAcalled && replacementBcalled && replacementDcalled, @"Replacement not called");
+}
+
+@end

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		0EAA1C141B4B371700FFB2FB /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */; };
 		0EAA1C171B4B372700FFB2FB /* IOHIDEvent+KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EAA1C111B4B371700FFB2FB /* IOHIDEvent+KIF.h */; };
 		0EAA1C181B4B372700FFB2FB /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */; };
+		12C111261CF40B3700390595 /* KIFProxyDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C111241CF40B3700390595 /* KIFProxyDelegate.h */; };
+		12C111271CF40B3700390595 /* KIFProxyDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C111251CF40B3700390595 /* KIFProxyDelegate.m */; };
+		12C111291CF410F900390595 /* ProxyDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C111281CF410F900390595 /* ProxyDelegateTests.m */; };
+		12C1112C1CF4127900390595 /* KIFScrollViewDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */; };
 		2CDEE1CB181DBED200DF6E63 /* PickerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CDEE1CA181DBED200DF6E63 /* PickerController.m */; };
 		2EE12710198991920031D347 /* MultiFingerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EE1270F198991920031D347 /* MultiFingerTests.m */; };
 		3812FB611A1212A700335733 /* AnimationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3812FB601A1212A700335733 /* AnimationViewController.m */; };
@@ -267,6 +271,12 @@
 /* Begin PBXFileReference section */
 		0EAA1C111B4B371700FFB2FB /* IOHIDEvent+KIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IOHIDEvent+KIF.h"; sourceTree = "<group>"; };
 		0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IOHIDEvent+KIF.m"; sourceTree = "<group>"; };
+		12C111241CF40B3700390595 /* KIFProxyDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFProxyDelegate.h; sourceTree = "<group>"; };
+		12C111251CF40B3700390595 /* KIFProxyDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFProxyDelegate.m; sourceTree = "<group>"; };
+		12C111281CF410F900390595 /* ProxyDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProxyDelegateTests.m; sourceTree = "<group>"; };
+		12C1112A1CF4127900390595 /* KIFScrollViewDelegates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFScrollViewDelegates.h; sourceTree = "<group>"; };
+		12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFScrollViewDelegates.m; sourceTree = "<group>"; };
+		12C1112D1CF4161000390595 /* KIFConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFConstants.h; sourceTree = "<group>"; };
 		2CDEE1CA181DBED200DF6E63 /* PickerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PickerController.m; sourceTree = "<group>"; };
 		2CED883D181F5EE1005ABD20 /* PickerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PickerTests.m; sourceTree = "<group>"; };
 		2EE1270F198991920031D347 /* MultiFingerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultiFingerTests.m; sourceTree = "<group>"; };
@@ -608,6 +618,11 @@
 				BD6A1CA01BCE8DD000EF07D2 /* KIFAccessibilityEnabler.m */,
 				0EAA1C111B4B371700FFB2FB /* IOHIDEvent+KIF.h */,
 				0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */,
+				12C111241CF40B3700390595 /* KIFProxyDelegate.h */,
+				12C111251CF40B3700390595 /* KIFProxyDelegate.m */,
+				12C1112A1CF4127900390595 /* KIFScrollViewDelegates.h */,
+				12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */,
+				12C1112D1CF4161000390595 /* KIFConstants.h */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -772,6 +787,7 @@
 				5A62B0AD1BB205CA00A3F480 /* PullToRefreshTests.m */,
 				EB60ED0A177F90BA005A041A /* SystemTests.m */,
 				5F6A1B371C191F9600F20F22 /* UIApplicationKIFAdditionsTests.m */,
+				12C111281CF410F900390595 /* ProxyDelegateTests.m */,
 				EB60ECF0177F8DB3005A041A /* Supporting Files */,
 			);
 			path = "KIF Tests";
@@ -926,6 +942,7 @@
 				EABD46A01857A0C700A5F081 /* KIFUITestActor.h in Headers */,
 				EABD46A11857A0C700A5F081 /* NSBundle-KIFAdditions.h in Headers */,
 				EAC8096A1864F19C000E819F /* NSException-KIFAdditions.h in Headers */,
+				12C111261CF40B3700390595 /* KIFProxyDelegate.h in Headers */,
 				EABD46961857A0C700A5F081 /* XCTestCase-KIFAdditions.h in Headers */,
 				E977D1071AA4062B005645BF /* UIEvent+KIFAdditions.h in Headers */,
 				BD6A1CA11BCE8DD000EF07D2 /* KIFAccessibilityEnabler.h in Headers */,
@@ -1218,6 +1235,7 @@
 				EB1A44D61A0C3268004A3F61 /* KIFUITestActor-IdentifierTests.m in Sources */,
 				EB2526491981BF7A00DBC747 /* KIFUITestActor-ConditionalTests.m in Sources */,
 				E977D1081AA4062B005645BF /* UIEvent+KIFAdditions.m in Sources */,
+				12C111271CF40B3700390595 /* KIFProxyDelegate.m in Sources */,
 				85DB946F1C5A3E860025F83E /* CALayer-KIFAdditions.m in Sources */,
 				EABD46871857A0C700A5F081 /* KIFSystemTestActor.m in Sources */,
 				EAC8096B1864F19C000E819F /* NSException-KIFAdditions.m in Sources */,
@@ -1237,6 +1255,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				12C111291CF410F900390595 /* ProxyDelegateTests.m in Sources */,
 				FA8A3C591A771C5500206350 /* SearchFieldTests_ViewTestActor.m in Sources */,
 				FA8A3C551A77157F00206350 /* LongPressTests_ViewTestActor.m in Sources */,
 				FA49155E1A78206E00A78E57 /* CompositionTests_ViewTestActor.m in Sources */,
@@ -1289,6 +1308,7 @@
 				FA4915651A7827D000A78E57 /* PickerTests_ViewTestActor.m in Sources */,
 				84D293B11A2C891700C10944 /* SystemAlertTests.m in Sources */,
 				BFE470901C7F44F700580EF9 /* UIScreen+KIFAdditionsTests.m in Sources */,
+				12C1112C1CF4127900390595 /* KIFScrollViewDelegates.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Instead of hard coded arbitrary waits, use scroll view proxy delegate to wait for scrolling to finish.
This removes the need to wait for an arbitrary amount of time (which may not be enough for slower machines, or may be too long for faster ones).
On a relatively new machine, this improves performance for lookups in scroll views (table views and collection views) by 2x and more.
